### PR TITLE
Puts back npm install.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -19,6 +19,7 @@ build:
     - mkdir -p shippable/testresults
     - mkdir -p shippable/codecoverage
     - psql -c 'CREATE DATABASE app_test;' -U postgres
+    - npm install
     - npm test
 # Generate coverage report with istanbul
   post_ci:


### PR DESCRIPTION
The `npm install` in `shippable.yml` got lost.  It should be somewhere before `npm test`.
